### PR TITLE
Add wildcard parameter to instances of class JAXBElement

### DIFF
--- a/src/main/java/com/massfords/jaxb/CreateJAXBElementNameCallback.java
+++ b/src/main/java/com/massfords/jaxb/CreateJAXBElementNameCallback.java
@@ -45,7 +45,7 @@ public class CreateJAXBElementNameCallback extends CodeCreator {
 
         Set<ClassOutline> named = onlyNamed(outline, classes);
 
-        JClass jaxbElementClass = outline.getCodeModel().ref(JAXBElement.class);
+        JClass jaxbElementClass = outline.getCodeModel().ref(JAXBElement.class).narrow(outline.getCodeModel().ref(Object.class).wildcard());
 
         for(ClassOutline classOutline : named) {
             JDefinedClass implClass = classOutline.implClass;

--- a/src/main/java/com/massfords/jaxb/TraversableCodeGenStrategy.java
+++ b/src/main/java/com/massfords/jaxb/TraversableCodeGenStrategy.java
@@ -104,7 +104,7 @@ public enum TraversableCodeGenStrategy {
         @Override
         public void collection(Outline outline, JBlock traverseBlock, JClass rawType, JVar beanParam, JMethod getter, JVar vizParam, JDefinedClass visitable, Set<JClass> directClasses) {
 
-            JClass jaxbElementClass = outline.getCodeModel().ref(JAXBElement.class);
+            JClass jaxbElementClass = outline.getCodeModel().ref(JAXBElement.class).narrow(outline.getCodeModel().ref(Object.class).wildcard());
 
             JForEach forEach = traverseBlock.forEach(rawType.getTypeParameters().get(0), "bean", JExpr.invoke(beanParam, getter));
             JBlock body = forEach.body();

--- a/src/test/resources/expected-direct/DepthFirstTraverserImpl.java.txt
+++ b/src/test/resources/expected-direct/DepthFirstTraverserImpl.java.txt
@@ -33,9 +33,9 @@ public class DepthFirstTraverserImpl<E extends Throwable >
             if (bean instanceof Visitable) {
                 ((Visitable) bean).accept(aVisitor);
             } else {
-                if (bean instanceof JAXBElement) {
-                    if (((JAXBElement) bean).getValue() instanceof Visitable) {
-                        ((Visitable)((JAXBElement) bean).getValue()).accept(aVisitor);
+                if (bean instanceof JAXBElement<?> ) {
+                    if (((JAXBElement<?> ) bean).getValue() instanceof Visitable) {
+                        ((Visitable)((JAXBElement<?> ) bean).getValue()).accept(aVisitor);
                     }
                 } else {
                     if (bean instanceof extended.Parameter) {

--- a/src/test/resources/expected-serializable/DepthFirstTraverserImpl.java.txt
+++ b/src/test/resources/expected-serializable/DepthFirstTraverserImpl.java.txt
@@ -53,9 +53,9 @@ public class DepthFirstTraverserImpl<E extends Throwable >
             if (bean instanceof Visitable) {
                 ((Visitable) bean).accept(aVisitor);
             } else {
-                if (bean instanceof JAXBElement) {
-                    if (((JAXBElement) bean).getValue() instanceof Visitable) {
-                        ((Visitable)((JAXBElement) bean).getValue()).accept(aVisitor);
+                if (bean instanceof JAXBElement<?> ) {
+                    if (((JAXBElement<?> ) bean).getValue() instanceof Visitable) {
+                        ((Visitable)((JAXBElement<?> ) bean).getValue()).accept(aVisitor);
                     }
                 }
             }

--- a/src/test/resources/expected/DepthFirstTraverserImpl.java.txt
+++ b/src/test/resources/expected/DepthFirstTraverserImpl.java.txt
@@ -52,9 +52,9 @@ public class DepthFirstTraverserImpl<E extends Throwable >
             if (bean instanceof Visitable) {
                 ((Visitable) bean).accept(aVisitor);
             } else {
-                if (bean instanceof JAXBElement) {
-                    if (((JAXBElement) bean).getValue() instanceof Visitable) {
-                        ((Visitable)((JAXBElement) bean).getValue()).accept(aVisitor);
+                if (bean instanceof JAXBElement<?> ) {
+                    if (((JAXBElement<?> ) bean).getValue() instanceof Visitable) {
+                        ((Visitable)((JAXBElement<?> ) bean).getValue()).accept(aVisitor);
                     }
                 }
             }

--- a/src/test/resources/ogc-expected/DepthFirstTraverserImpl.java.txt
+++ b/src/test/resources/ogc-expected/DepthFirstTraverserImpl.java.txt
@@ -360,9 +360,9 @@ public class DepthFirstTraverserImpl<E extends Throwable >
             if (bean instanceof Visitable) {
                 ((Visitable) bean).accept(aVisitor);
             } else {
-                if (bean instanceof JAXBElement) {
-                    if (((JAXBElement) bean).getValue() instanceof Visitable) {
-                        ((Visitable)((JAXBElement) bean).getValue()).accept(aVisitor);
+                if (bean instanceof JAXBElement<?> ) {
+                    if (((JAXBElement<?> ) bean).getValue() instanceof Visitable) {
+                        ((Visitable)((JAXBElement<?> ) bean).getValue()).accept(aVisitor);
                     }
                 }
             }
@@ -621,9 +621,9 @@ public class DepthFirstTraverserImpl<E extends Throwable >
             if (bean instanceof Visitable) {
                 ((Visitable) bean).accept(aVisitor);
             } else {
-                if (bean instanceof JAXBElement) {
-                    if (((JAXBElement) bean).getValue() instanceof Visitable) {
-                        ((Visitable)((JAXBElement) bean).getValue()).accept(aVisitor);
+                if (bean instanceof JAXBElement<?> ) {
+                    if (((JAXBElement<?> ) bean).getValue() instanceof Visitable) {
+                        ((Visitable)((JAXBElement<?> ) bean).getValue()).accept(aVisitor);
                     }
                 }
             }


### PR DESCRIPTION
I get warnings in Eclipse in the generated code because uses of JAXBElement are not parameterized. This commit fixes that.