### PR TITLE
Allow including type name in generated methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ jaxb-visitor.iml
 jaxb-visitor.ipr
 jaxb-visitor.iws
 target
+.classpath
+.project
+.settings/

--- a/src/main/java/com/massfords/jaxb/AddAcceptMethod.java
+++ b/src/main/java/com/massfords/jaxb/AddAcceptMethod.java
@@ -12,6 +12,12 @@ import java.util.Set;
  */
 public class AddAcceptMethod {
 
+    private boolean includeType;
+
+    public AddAcceptMethod(boolean includeType) {
+        this.includeType = includeType;
+    }
+
     public void run(Set<ClassOutline> sorted, JDefinedClass visitor) {
         for (ClassOutline classOutline : sorted) {
             // skip over abstract classes
@@ -26,7 +32,10 @@ public class AddAcceptMethod {
         		final JClass narrowedVisitor = visitor.narrow(returnType, exceptionType);
         		JVar vizParam = acceptMethod.param(narrowedVisitor, "aVisitor");
                 JBlock block = acceptMethod.body();
-                block._return(vizParam.invoke("visit").arg(JExpr._this()));
+                if (includeType)
+                    block._return(vizParam.invoke("visit" + beanImpl.name()).arg(JExpr._this()));
+                else
+                    block._return(vizParam.invoke("visit").arg(JExpr._this()));
             }
         }
     }

--- a/src/main/java/com/massfords/jaxb/CreateBaseVisitorClass.java
+++ b/src/main/java/com/massfords/jaxb/CreateBaseVisitorClass.java
@@ -23,10 +23,12 @@ import static com.massfords.jaxb.ClassDiscoverer.allConcreteClasses;
 public class CreateBaseVisitorClass extends CodeCreator {
 
     private JDefinedClass visitor;
+    private boolean includeType;
 
-    public CreateBaseVisitorClass(JDefinedClass visitor, Outline outline, JPackage jPackage) {
+    public CreateBaseVisitorClass(JDefinedClass visitor, Outline outline, JPackage jPackage, boolean includeType) {
         super(outline, jPackage);
         this.visitor = visitor;
+        this.includeType = includeType;
     }
     
     @Override
@@ -44,7 +46,11 @@ public class CreateBaseVisitorClass extends CodeCreator {
     }
 
     private void implementVisitMethod(JTypeVar returnType, JTypeVar exceptionType, JClass implClass) {
-        JMethod _method = getOutput().method(JMod.PUBLIC, returnType, "visit");
+        JMethod _method;
+        if (includeType)
+            _method = getOutput().method(JMod.PUBLIC, returnType, "visit" + implClass.name());
+        else
+            _method = getOutput().method(JMod.PUBLIC, returnType, "visit");
         _method._throws(exceptionType);
         _method.param(implClass, "aBean");
         _method.body()._return(JExpr._null());

--- a/src/main/java/com/massfords/jaxb/CreateDepthFirstTraverserClass.java
+++ b/src/main/java/com/massfords/jaxb/CreateDepthFirstTraverserClass.java
@@ -35,14 +35,16 @@ public class CreateDepthFirstTraverserClass extends CodeCreator {
     private JDefinedClass visitor;
     private JDefinedClass traverser;
     private JDefinedClass visitable;
+    private boolean includeType;
 
     public CreateDepthFirstTraverserClass(JDefinedClass visitor, JDefinedClass traverser, JDefinedClass visitable,
                                           Outline outline,
-                                          JPackage jPackageackage) {
+                                          JPackage jPackageackage, boolean includeType) {
         super(outline, jPackageackage);
         this.visitor = visitor;
         this.traverser = traverser;
         this.visitable = visitable;
+        this.includeType = includeType;
     }
 
     @Override
@@ -71,7 +73,11 @@ public class CreateDepthFirstTraverserClass extends CodeCreator {
                     continue;
                 }
                 // add the bean to the traverserImpl
-                JMethod traverseMethodImpl = defaultTraverser.method(JMod.PUBLIC, void.class, "traverse");
+                JMethod traverseMethodImpl;
+                if (includeType)
+                    traverseMethodImpl = defaultTraverser.method(JMod.PUBLIC, void.class, "traverse" + classOutline.implClass.name());
+                else
+                    traverseMethodImpl = defaultTraverser.method(JMod.PUBLIC, void.class, "traverse");
                 traverseMethodImpl._throws(exceptionType);
                 JVar beanParam = traverseMethodImpl.param(classOutline.implClass, "aBean");
                 JVar vizParam = traverseMethodImpl.param(narrowedVisitor, "aVisitor");

--- a/src/main/java/com/massfords/jaxb/CreateTraverserInterface.java
+++ b/src/main/java/com/massfords/jaxb/CreateTraverserInterface.java
@@ -21,10 +21,12 @@ import static com.massfords.jaxb.ClassDiscoverer.allConcreteClasses;
 public class CreateTraverserInterface extends CodeCreator {
     
     private JDefinedClass visitor;
+    private boolean includeType;
 
-    public CreateTraverserInterface(JDefinedClass visitor, Outline outline, JPackage jpackage) {
+    public CreateTraverserInterface(JDefinedClass visitor, Outline outline, JPackage jpackage, boolean includeType) {
         super(outline, jpackage);
         this.visitor = visitor;
+        this.includeType = includeType;
     }
 
     @Override
@@ -46,7 +48,11 @@ public class CreateTraverserInterface extends CodeCreator {
     }
 
     private void implTraverse(JTypeVar exceptionType, JClass narrowedVisitor, JClass implClass) {
-        JMethod traverseMethod = getOutput().method(JMod.PUBLIC, void.class, "traverse");
+        JMethod traverseMethod;
+        if (includeType)
+            traverseMethod = getOutput().method(JMod.PUBLIC, void.class, "traverse" + implClass.name());
+        else
+            traverseMethod = getOutput().method(JMod.PUBLIC, void.class, "traverse");
         traverseMethod._throws(exceptionType);
         traverseMethod.param(implClass, "aBean");
         traverseMethod.param(narrowedVisitor, "aVisitor");

--- a/src/main/java/com/massfords/jaxb/CreateTraversingVisitorClass.java
+++ b/src/main/java/com/massfords/jaxb/CreateTraversingVisitorClass.java
@@ -20,13 +20,15 @@ public class CreateTraversingVisitorClass extends CodeCreator {
     private JDefinedClass progressMonitor;
     private JDefinedClass visitor;
     private JDefinedClass traverser;
+    private boolean includeType;
 
     public CreateTraversingVisitorClass(JDefinedClass visitor, JDefinedClass progressMonitor,
-                                        JDefinedClass traverser, Outline outline, JPackage jPackage) {
+                                        JDefinedClass traverser, Outline outline, JPackage jPackage, boolean includeType) {
         super(outline, jPackage);
         this.visitor = visitor;
         this.traverser = traverser;
         this.progressMonitor = progressMonitor;
+        this.includeType = includeType;
     }
 
     @Override
@@ -64,7 +66,11 @@ public class CreateTraversingVisitorClass extends CodeCreator {
 
     private void generateForDirectClass(JDefinedClass traversingVisitor, JTypeVar returnType, JTypeVar exceptionType, JClass implClass) {
         // add method impl to traversing visitor
-        JMethod travViz = traversingVisitor.method(JMod.PUBLIC, returnType, "visit");
+        JMethod travViz;
+        if (includeType)
+            travViz = traversingVisitor.method(JMod.PUBLIC, returnType, "visit" + implClass.name());
+        else
+            travViz = traversingVisitor.method(JMod.PUBLIC, returnType, "visit");
         travViz._throws(exceptionType);
         JVar beanVar = travViz.param(implClass, "aBean");
         travViz.annotate(Override.class);
@@ -74,7 +80,10 @@ public class CreateTraversingVisitorClass extends CodeCreator {
 
         JVar retVal = travVizBloc.decl(returnType, "returnVal");
 
-        travVizBloc.assign(retVal, JExpr.invoke(JExpr.invoke("getVisitor"), "visit").arg(beanVar));
+        if (includeType)
+	        travVizBloc.assign(retVal, JExpr.invoke(JExpr.invoke("getVisitor"), "visit" + implClass.name()).arg(beanVar));
+        else
+	        travVizBloc.assign(retVal, JExpr.invoke(JExpr.invoke("getVisitor"), "visit").arg(beanVar));
 
         travVizBloc._if(JExpr.ref("progressMonitor").ne(JExpr._null()))._then().invoke(JExpr.ref("progressMonitor"), "visited").arg(beanVar);
 
@@ -85,7 +94,11 @@ public class CreateTraversingVisitorClass extends CodeCreator {
 
     private void generate(JDefinedClass traversingVisitor, JTypeVar returnType, JTypeVar exceptionType, JClass implClass) {
         // add method impl to traversing visitor
-        JMethod travViz = traversingVisitor.method(JMod.PUBLIC, returnType, "visit");
+        JMethod travViz;
+        if (includeType)
+            travViz = traversingVisitor.method(JMod.PUBLIC, returnType, "visit" + implClass.name());
+        else
+            travViz = traversingVisitor.method(JMod.PUBLIC, returnType, "visit");
         travViz._throws(exceptionType);
         JVar beanVar = travViz.param(implClass, "aBean");
         travViz.annotate(Override.class);
@@ -108,7 +121,10 @@ public class CreateTraversingVisitorClass extends CodeCreator {
 
         // case to traverse before the visit
         JBlock block = travVizBloc._if(JExpr.ref("traverseFirst").eq(JExpr.lit(flag)))._then();
-        block.invoke(JExpr.invoke("getTraverser"), "traverse").arg(beanVar).arg(JExpr._this());
+        if (includeType)
+            block.invoke(JExpr.invoke("getTraverser"), "traverse" + beanVar.type().name()).arg(beanVar).arg(JExpr._this());
+        else
+            block.invoke(JExpr.invoke("getTraverser"), "traverse").arg(beanVar).arg(JExpr._this());
         block._if(JExpr.ref("progressMonitor").ne(JExpr._null()))._then().invoke(JExpr.ref("progressMonitor"), "traversed").arg(beanVar);
     }
 

--- a/src/main/java/com/massfords/jaxb/CreateVisitorInterface.java
+++ b/src/main/java/com/massfords/jaxb/CreateVisitorInterface.java
@@ -20,8 +20,11 @@ import static com.massfords.jaxb.ClassDiscoverer.allConcreteClasses;
  */
 public class CreateVisitorInterface extends CodeCreator {
     
-    public CreateVisitorInterface(Outline outline, JPackage jPackage) {
+    private boolean includeType;
+
+    public CreateVisitorInterface(Outline outline, JPackage jPackage, boolean includeType) {
         super(outline, jPackage);
+        this.includeType = includeType;
     }
     
     @Override
@@ -41,7 +44,11 @@ public class CreateVisitorInterface extends CodeCreator {
     }
 
     private void declareVisitMethod(JTypeVar returnType, JTypeVar exceptionType, JClass implClass) {
-        JMethod vizMethod = getOutput().method(JMod.PUBLIC, returnType, "visit");
+        JMethod vizMethod;
+        if (includeType)
+            vizMethod = getOutput().method(JMod.PUBLIC, returnType, "visit" + implClass.name());
+        else
+            vizMethod = getOutput().method(JMod.PUBLIC, returnType, "visit");
         vizMethod._throws(exceptionType);
         vizMethod.param(implClass, "aBean");
     }


### PR DESCRIPTION
This change adds an option to include type names in generated visit(..)/traverse(..) methods.  This is needed to get around serious performance hits on projects with many classes due to Java's inability to cope with wildly overloaded methods.