### PR TITLE
Compile with Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
             <version>2.3.5</version>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>2.2.1</version>


### PR DESCRIPTION
The only thing missing to make this project compile is missing A javax.annotation dependency.
Adding this dependency will make it compile with Java 11.